### PR TITLE
image/jpeg: fix bad RST marker panic caused by alignment byte

### DIFF
--- a/src/image/jpeg/scan.go
+++ b/src/image/jpeg/scan.go
@@ -310,6 +310,15 @@ func (d *decoder) processSOS(n int) error {
 				if err := d.readFull(d.tmp[:2]); err != nil {
 					return err
 				}
+				
+				// detect the presence of a stuffed 0xff00 pair caused by byte alignment before RST marker
+				if d.tmp[0] == 0xff && d.tmp[1] == 0x00 {
+					if err := d.readFull(d.tmp[:2]); err != nil {
+						return err
+					}
+				}
+
+				
 				if d.tmp[0] != 0xff || d.tmp[1] != expectedRST {
 					return FormatError("bad RST marker")
 				}


### PR DESCRIPTION
JPEG standard allows for stuffed bytes just before the reset markers in order to align bytes (refer to B 1, D 1.6, and F 1.2.3 of JPEG spec). Some JPEG encoders seem to use these even when byte alignment is not strictly necessary. This fix checks for and skips over the escaped stuffed byte.

Fixes #28717